### PR TITLE
Implement AsRawFd for Socket to allow FD access

### DIFF
--- a/xdp-socket/src/socket.rs
+++ b/xdp-socket/src/socket.rs
@@ -37,7 +37,7 @@
 use crate::mmap::OwnedMmap;
 use crate::ring::{Ring, XdpDesc};
 use std::fmt::Display;
-use std::os::fd::{AsRawFd as _, OwnedFd};
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
 use std::{io, ptr};
 
@@ -265,5 +265,19 @@ impl Inner {
     /// Constructs a new `Inner` with the given UMEM and file descriptor.
     pub(crate) fn new(umem: OwnedMmap, fd: OwnedFd) -> Self {
         Self { umem, fd }
+    }
+}
+
+impl<const t: _Direction> AsRawFd for Socket<t> {
+    /// Returns the underlying raw file descriptor.
+    ///
+    /// This is useful for interoperability with other crates (e.g., registering
+    /// the socket in an eBPF map via `aya`).
+    ///
+    /// # Returns
+    ///
+    /// The underlying raw file descriptor.
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_fd
     }
 }


### PR DESCRIPTION
Hello there. I'm currently using xdp_rs in combination with aya to load a custom XDP program. To redirect packets from my eBPF program to the userspace socket, I need to register the socket's file descriptor in an XSKMAP.

Currently, the raw_fd field is pub(crate), making it impossible to access the FD from outside the crate.

Thus I implemented the standard std::os::fd::AsRawFd trait for Socket. This allows users to retrieve the FD safely for use cases like map registration, without exposing internal implementation details, which would be a very handy addition to this practical crate.