### PR TITLE
important fix: Descriptors overwritten during TX ring reclaim (seek_)

### DIFF
--- a/xdp-socket/src/seek.rs
+++ b/xdp-socket/src/seek.rs
@@ -58,11 +58,14 @@ impl Seek_<_TX> for Socket<_TX> {
         } else {
             loop {
                 let c_head = self.consumer & c_ring.mod_mask;
+                if self.available as usize >= self.x_ring.len {
+                    break;
+                }
                 let addr = c_ring.desc_at(c_head);
                 let desc = XdpDesc::new(addr, 0, 0);
                 self.consumer = self.consumer.wrapping_add(1);
                 c_ring.update_consumer(self.consumer);
-                let x_head = self.producer & self.x_ring.mod_mask;
+                let x_head = self.producer.wrapping_add(self.available) & self.x_ring.mod_mask;
                 *self.x_ring.mut_desc_at(x_head) = desc;
                 self.available += 1;
                 if self.available as usize >= count || c_producer == self.consumer {


### PR DESCRIPTION
1. Fixed a bug where multiple reclaimed descriptors were written to the exact same `x_ring` slot when `count > 1`. The write index (`x_head`) was static inside the loop. It is now offset by `self.available` during each iteration, ensuring consecutive slots are used.

2. Added a bounds check to prevent overwriting unwritten descriptors in the `x_ring` when `count` exceeds the ring's total capacity.

Fixes #3 