### PR TITLE
socket initialization and incorrect bitmask usage

### DIFF
--- a/xdp-socket/src/commit.rs
+++ b/xdp-socket/src/commit.rs
@@ -91,7 +91,7 @@ impl Commit_<_RX> for Socket<_RX> {
         let x_ring = &mut self.x_ring;
         for _ in 0..(count as u32) {
             let addr = x_ring.desc_at(self.consumer & x_ring.mod_mask).addr;
-            *f_ring.mut_desc_at(self.producer & x_ring.mod_mask) = addr;
+            *f_ring.mut_desc_at(self.producer & f_ring.mod_mask) = addr;
             self.consumer = self.consumer.wrapping_add(1);
             self.producer = self.producer.wrapping_add(1);
         }

--- a/xdp-socket/src/socket.rs
+++ b/xdp-socket/src/socket.rs
@@ -117,7 +117,7 @@ where
             let raw_fd = inner.fd.as_raw_fd();
             Self {
                 frames,
-                available: x_ring.len as u32,
+                available: if t { x_ring.len as u32 } else { 0 },
                 producer: 0,
                 consumer: 0,
                 raw_fd,


### PR DESCRIPTION
Fixed a bug where the `x_ring.mod_mask` was used instead of `f_ring.mod_mask` when committing descriptors to the fill ring. This ensures correct index calculation even if the rings have different sizes.

Fixes #5 

Fixed a bug where the `available` counter in `Socket::new` was always initialized to `x_ring.len`. It now correctly checks the direction type `t` and initializes `available` to `0` for RX sockets, while keeping it at `x_ring.len` for TX sockets.

Fixes #6 